### PR TITLE
Update wormhole-gui mention after project rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A graphical user interface for [Magic Wormhole](https://github.com/warner/magic-wormhole). 
 
-Project is currently not actively developed. See [Wormhole GUI](https://github.com/jacalz/wormhole-gui) as a alternative.
+Project is currently not actively developed. See [Rymdport](https://github.com/jacalz/rymdport) as an alternative.
 
 ## Screenshots
 


### PR DESCRIPTION
I decided to rename wormhole-gui to Rymdport. The meaning behind the new name can be found here: https://github.com/Jacalz/rymdport#name